### PR TITLE
itcarroll patch 1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,8 @@ packages = [{include = "sarp_east_toolkit"}]
 python = "^3.9"
 requests = "^2.28.1"
 s3fs = "^2022.5.0"
+boto3 = "^1.21.21"
+rasterio = "^1.3.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.3.1"

--- a/sarp_east_toolkit/__init__.py
+++ b/sarp_east_toolkit/__init__.py
@@ -1,2 +1,3 @@
 from .earthdata import earthdata_login
 from .earthdata import earthdata_s3fs
+from .earthdata import earthdata_rio


### PR DESCRIPTION
Adds a method for returning a rasterio.Env, derived from a boto3 session, that is [needed](https://nasa-openscapes.github.io/2021-Cloud-Hackathon/tutorials/05_Data_Access_Direct_S3.html) for rioxarray.open_rasterio.